### PR TITLE
image plugin variables

### DIFF
--- a/plugins/image/image.js
+++ b/plugins/image/image.js
@@ -220,7 +220,7 @@ var image = (function(image_plugin) {
      */
     var uploadButtonClicked_ = function(event) {
 
-        let url        = image_plugin.config.uploadImage,
+        var url        = image_plugin.config.uploadImage,
             beforeSend = uploadingCallbacks_.ByClick.beforeSend,
             success    = uploadingCallbacks_.ByClick.success,
             error      = uploadingCallbacks_.ByClick.error;


### PR DESCRIPTION
Plugins doesn’t uses babel polyfill. That’s why ‘let’ won’t work.